### PR TITLE
feat(security): Implement quick wins security batch

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,19 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: npm ci
+      - run: npm audit

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self' https://booky.buzz;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self' https://booky.buzz; object-src 'none'; base-uri 'self';">
     <meta charset="UTF-8" />
     <link rel="canonical" href="https://jadenmaciel.github.io/wesleys-cpr/" />
     <link rel="icon" type="image/png" sizes="32x32" href="%BASE_URL%images/logo.png" />

--- a/src/components/Booking.tsx
+++ b/src/components/Booking.tsx
@@ -35,7 +35,7 @@ export default function Booking() {
             href={PUBLIC_BOOKING_URL}
             className="text-red font-semibold underline underline-offset-2 ml-1"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >
             open the booking page directly.
           </a>
@@ -47,6 +47,8 @@ export default function Booking() {
             id="buzz-widget"
             style={{ width: '100%', minWidth: 320, border: 0, height: 720 }}
             loading="lazy"
+            sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
+            allow="payment"
           />
         </div>
         <p className="mt-4 text-xs text-navy/70 text-center">

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,17 +1,37 @@
 import { MapPin, Phone, Mail, Clock } from 'lucide-react';
 import { useState } from 'react';
+import { z } from 'zod';
+
+const contactSchema = z.object({
+  name: z.string().min(1, { message: 'Full name is required' }),
+  email: z.string().email({ message: 'Invalid email address' }),
+  phone: z.string().optional(),
+  message: z.string().min(1, { message: 'Message is required' }),
+});
+
+type ContactForm = z.infer<typeof contactSchema>;
+type FormErrors = z.ZodError<ContactForm>['formErrors']['fieldErrors'];
 
 export default function Contact() {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<ContactForm>({
     name: '',
     email: '',
     phone: '',
     message: '',
   });
+  const [errors, setErrors] = useState<FormErrors>({});
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const result = contactSchema.safeParse(formData);
+    if (!result.success) {
+      setErrors(result.error.formErrors.fieldErrors);
+      return;
+    }
     // TODO: Implement form submission logic (e.g., send to an API endpoint)
+    console.log('Form submitted successfully:', result.data);
+    setErrors({});
+    setFormData({ name: '', email: '', phone: '', message: '' });
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -112,10 +132,10 @@ export default function Contact() {
                   name="name"
                   value={formData.name}
                   onChange={handleChange}
-                  required
                   className="w-full px-4 py-3 border border-red rounded-lg outline-none transition focus:ring-2 focus:ring-red text-dark"
                   placeholder="John Doe"
                 />
+                {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name[0]}</p>}
               </div>
 
               <div>
@@ -128,10 +148,10 @@ export default function Contact() {
                   name="email"
                   value={formData.email}
                   onChange={handleChange}
-                  required
                   className="w-full px-4 py-3 border border-red rounded-lg outline-none transition focus:ring-2 focus:ring-red text-dark"
                   placeholder="john@example.com"
                 />
+                {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email[0]}</p>}
               </div>
 
               <div>
@@ -158,11 +178,11 @@ export default function Contact() {
                   name="message"
                   value={formData.message}
                   onChange={handleChange}
-                  required
                   rows={5}
                   className="w-full px-4 py-3 border border-red rounded-lg outline-none transition resize-none focus:ring-2 focus:ring-red text-dark"
                   placeholder="Tell us about your training needs..."
                 />
+                {errors.message && <p className="text-red-500 text-sm mt-1">{errors.message[0]}</p>}
               </div>
 
               <button


### PR DESCRIPTION
This commit implements the following security improvements:

- Adds Zod validation to the contact form with inline error messages.
- Adds rel='noopener noreferrer' to external links.
- Adds sandbox and allow attributes to the booking iframe.
- Implements a more restrictive Content Security Policy.
- Adds a GitHub Actions workflow for running npm audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens CSP, adds Zod validation with inline errors to the contact form, secures external link and booking iframe attributes, and introduces a scheduled npm audit workflow.
> 
> - **Security/HTML**:
>   - Tighten CSP in `index.html` (`script-src 'self'`, add `object-src 'none'`, `base-uri 'self'`; keep allowed `frame-src` for `https://booky.buzz`).
> - **Frontend**:
>   - `src/components/Booking.tsx`:
>     - Add `rel="noopener noreferrer"` to external link.
>     - Add `sandbox="allow-scripts allow-forms allow-popups allow-same-origin"` and `allow="payment"` to booking `iframe`.
>   - `src/components/Contact.tsx`:
>     - Implement Zod schema validation with typed form state and inline error messages.
> - **CI**:
>   - Add GitHub Actions workflow `.github/workflows/security.yml` to run `npm ci` and `npm audit` on `main` pushes and weekly schedule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c717abb3678fd1b986b8b3d27139c7161f6fc25d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->