### PR TITLE
fix(security): Correct Zod error handling in Contact.tsx

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -10,7 +10,7 @@ const contactSchema = z.object({
 });
 
 type ContactForm = z.infer<typeof contactSchema>;
-type FormErrors = z.ZodError<ContactForm>['formErrors']['fieldErrors'];
+type FormErrors = ReturnType<z.ZodError<ContactForm>['flatten']>['fieldErrors'];
 
 export default function Contact() {
   const [formData, setFormData] = useState<ContactForm>({
@@ -25,7 +25,7 @@ export default function Contact() {
     e.preventDefault();
     const result = contactSchema.safeParse(formData);
     if (!result.success) {
-      setErrors(result.error.formErrors.fieldErrors);
+      setErrors(result.error.flatten().fieldErrors);
       return;
     }
     // TODO: Implement form submission logic (e.g., send to an API endpoint)


### PR DESCRIPTION
Updates Zod error handling to use error.flatten().fieldErrors and adjusts the FormErrors type definition as per Zod's API, resolving a build failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Contact form validation to `error.flatten().fieldErrors` and updates `FormErrors` type to match Zod, resolving type/build issues.
> 
> - **Contact form (`src/components/Contact.tsx`)**:
>   - Validation: Replace `error.formErrors.fieldErrors` with `error.flatten().fieldErrors`.
>   - Types: Update `FormErrors` to `ReturnType<z.ZodError<ContactForm>['flatten']>['fieldErrors']`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 210c3bc46ccf6a109a518f46a6c7525237981a2c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->