### PR TITLE
ci(security): Enhance security scanning with npm audit and ZAP

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,12 +2,12 @@ name: Security Audit
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, security ]
   schedule:
     - cron: '0 0 * * 0'
 
 jobs:
-  audit:
+  npm-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,4 +16,13 @@ jobs:
         with:
           node-version: '18.x'
       - run: npm ci
-      - run: npm audit
+      - run: npm audit --audit-level=high
+
+  zap-baseline-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ZAP Scan
+        uses: zaproxy/action-baseline@v0.11.0
+        with:
+          target: 'https://jadenmaciel.github.io/wesleys-cpr/'
+          fail_action: true


### PR DESCRIPTION
This commit enhances the security CI workflow by:

- Updating npm audit to fail on high-severity vulnerabilities.
- Adding an OWASP ZAP baseline scan against the deployed site.
- Introducing a Dependabot configuration for weekly npm dependency updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Dependabot for weekly npm updates and strengthens the security workflow by enforcing high-severity npm audit and running an OWASP ZAP baseline scan on main/security branches.
> 
> - **CI/CD — Security**:
>   - Triggers on `main` and `security` branches.
>   - Tightens `npm audit` to `--audit-level=high`.
>   - Adds OWASP ZAP baseline scan via `zaproxy/action-baseline@v0.11.0` targeting `https://jadenmaciel.github.io/wesleys-cpr/` with `fail_action: true`.
> - **Dependencies**:
>   - Introduces `.github/dependabot.yml` for weekly `npm` updates with `chore(deps)` scoped commit messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caed912e9fa550710c2c483fdae81af9b9aed1df. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->