### PR TITLE
Fixed TS error TS2304 in src/routes/Privacy.tsx

### DIFF
--- a/src/routes/Privacy.tsx
+++ b/src/routes/Privacy.tsx
@@ -40,7 +40,7 @@ export default function Privacy() {
             <p>If waiver capture is re-enabled:</p>
             <ul>
               <li><strong>Location:</strong> AWS S3 (private bucket, encrypted at rest)</li>
-              <li><strong>Format:</strong> JSON files organized by date (<code>waivers/YYYY/MM/DD/{uuid}.json</code>)</li>
+              <li><strong>Format:</strong> JSON files organized by date (<code>{'waivers/YYYY/MM/DD/{uuid}.json'}</code>)</li>
               <li><strong>Access:</strong> Private bucket with no public access; only authorized AWS services can write</li>
               <li><strong>Versioning:</strong> Enabled for audit trail and recovery</li>
             </ul>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes a TypeScript issue by wrapping the S3 path example in a string literal in `src/routes/Privacy.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aba9341bde93351caf0323c07f5011a19b0dd09e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->